### PR TITLE
fix(#3): login, base entity, role 수정 (#136)

### DIFF
--- a/src/main/java/com/example/Spot/global/common/AuditorAwareImpl.java
+++ b/src/main/java/com/example/Spot/global/common/AuditorAwareImpl.java
@@ -1,0 +1,33 @@
+package com.example.Spot.global.common;
+
+import java.util.Optional;
+
+import org.springframework.data.domain.AuditorAware;
+import org.springframework.security.authentication.AnonymousAuthenticationToken;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.stereotype.Component;
+
+import com.example.Spot.infra.auth.security.CustomUserDetails;
+
+@Component
+public class AuditorAwareImpl implements AuditorAware<Integer> {
+
+    @Override
+    public Optional<Integer> getCurrentAuditor() {
+        Authentication auth = SecurityContextHolder.getContext().getAuthentication();
+
+        if (auth == null
+                || !auth.isAuthenticated()
+                || auth instanceof AnonymousAuthenticationToken) {
+            return Optional.of(0); // SYSTEM
+        }
+
+        Object principal = auth.getPrincipal();
+        if (principal instanceof CustomUserDetails cud) {
+            return Optional.of(cud.getUserId());
+        }
+
+        return Optional.of(0);
+    }
+}

--- a/src/main/java/com/example/Spot/global/common/BaseEntity.java
+++ b/src/main/java/com/example/Spot/global/common/BaseEntity.java
@@ -2,6 +2,7 @@ package com.example.Spot.global.common;
 
 import java.time.LocalDateTime;
 
+import org.springframework.data.annotation.CreatedBy;
 import org.springframework.data.annotation.CreatedDate;
 import org.springframework.data.jpa.domain.support.AuditingEntityListener;
 
@@ -21,6 +22,7 @@ public abstract class BaseEntity {
     @Column(name = "created_at", updatable = false, nullable = false)
     private LocalDateTime createdAt;
 
+    @CreatedBy
     @Column(name = "created_by", updatable = false, nullable = false)
     private Integer createdBy;
 

--- a/src/main/java/com/example/Spot/global/common/UpdateBaseEntity.java
+++ b/src/main/java/com/example/Spot/global/common/UpdateBaseEntity.java
@@ -25,7 +25,7 @@ public abstract class UpdateBaseEntity extends BaseEntity {
     private Integer updatedBy;
 
     @Column(name = "is_deleted", nullable = false)
-    private Boolean isDeleted;
+    private boolean isDeleted;
 
     @Column(name = "deleted_at")
     private LocalDateTime deletedAt;
@@ -37,7 +37,12 @@ public abstract class UpdateBaseEntity extends BaseEntity {
         super(createdBy);
         this.isDeleted = false;
     }
-    
+
+    public boolean getIsDeleted() {
+        return isDeleted;
+    }
+
+
     public void softDelete(Integer deletedBy) {
         this.isDeleted = true;
         this.deletedBy = deletedBy;

--- a/src/main/java/com/example/Spot/global/infrastructure/config/security/SecurityConfig.java
+++ b/src/main/java/com/example/Spot/global/infrastructure/config/security/SecurityConfig.java
@@ -49,6 +49,10 @@ public class SecurityConfig {
     @Bean
     public SecurityFilterChain filterChain(HttpSecurity http) throws Exception {
 
+        LoginFilter loginFilter =
+                new LoginFilter(authenticationManager(authenticationConfiguration), jwtUtil);
+        loginFilter.setFilterProcessesUrl("/api/login");
+
         // CSRF disable
         http
                 .csrf(auth -> auth.disable());
@@ -79,8 +83,10 @@ public class SecurityConfig {
         );
 
         //필터 추가 LoginFilter()는 인자를 받음 (AuthenticationManager() 메소드에 authenticationConfiguration 객체를 넣어야 함) 따라서 등록 필요
-        http
-                .addFilterAt(new LoginFilter(authenticationManager(authenticationConfiguration), jwtUtil), UsernamePasswordAuthenticationFilter.class);
+        http.addFilterAt(
+                loginFilter,
+                UsernamePasswordAuthenticationFilter.class
+        );
 
         http
                 .sessionManagement(session -> session

--- a/src/main/java/com/example/Spot/infra/auth/jwt/LoginFilter.java
+++ b/src/main/java/com/example/Spot/infra/auth/jwt/LoginFilter.java
@@ -1,5 +1,7 @@
 package com.example.Spot.infra.auth.jwt;
 
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
 import org.springframework.security.authentication.AuthenticationManager;
 import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
 import org.springframework.security.core.Authentication;
@@ -31,16 +33,23 @@ public class LoginFilter extends UsernamePasswordAuthenticationFilter {
 
     @Override
     public Authentication attemptAuthentication(HttpServletRequest request, HttpServletResponse response) throws AuthenticationException {
-        // 클라이언트 요청에서 username, password 추출
-        String username = obtainUsername(request);
-        String password = obtainPassword(request);
+        try {
+            // JSON body 읽기, 파싱
+            String body = request.getReader().lines().reduce("", (a, b) -> a + b);
+            ObjectMapper om = new ObjectMapper();
+            JsonNode json = om.readTree(body);
 
-        // 스프링 시큐리티에서 username과 password를 검증하기 위해서는 token에 담아야 함
-        // null - 추후에 role 등으로
-        UsernamePasswordAuthenticationToken authToken = new UsernamePasswordAuthenticationToken(username, password, null);
+            String username = json.get("username").asText();
+            String password = json.get("password").asText();
 
-        //token에 담은 검증을 위한 AuthenticationManager로 전달
-        return authenticationManager.authenticate(authToken);
+            UsernamePasswordAuthenticationToken authToken =
+                    new UsernamePasswordAuthenticationToken(username, password);
+
+            return authenticationManager.authenticate(authToken);
+
+        } catch (Exception e) {
+            throw new RuntimeException(e);
+        }
     }
 
     @Override

--- a/src/main/java/com/example/Spot/infra/auth/security/CustomUserDetails.java
+++ b/src/main/java/com/example/Spot/infra/auth/security/CustomUserDetails.java
@@ -37,14 +37,6 @@ public class CustomUserDetails implements UserDetails {
         Collection<GrantedAuthority> collection = new ArrayList<>();
 
         collection.add(() -> "ROLE_" + userEntity.getRole().name());
-//        collection.add(new GrantedAuthority() {
-//
-//            @Override
-//            public String getAuthority() {
-//
-//                return String.valueOf(userEntity.getRole());
-//            }
-//        });
 
         return collection;
     }

--- a/src/main/java/com/example/Spot/menu/application/service/MenuOptionServiceImpl.java
+++ b/src/main/java/com/example/Spot/menu/application/service/MenuOptionServiceImpl.java
@@ -124,7 +124,7 @@ public class MenuOptionServiceImpl implements MenuOptionService {
         // 권한 검증
         validatePermission(store, user);
 
-        option.softDelete();
+        option.softDelete(user.getId());
     }
 
     // Helper

--- a/src/main/java/com/example/Spot/menu/application/service/MenuServiceImpl.java
+++ b/src/main/java/com/example/Spot/menu/application/service/MenuServiceImpl.java
@@ -137,7 +137,7 @@ public class MenuServiceImpl implements MenuService {
         // 유저가 이 가게 소속인지 확인
         validateOwner(menu.getStore(), user, "본인 가게의 메뉴만 삭제할 수 있습니다.");
 
-        menu.softDelete();
+        menu.softDelete(user.getId());
     }
 
     // 7. 메뉴 숨김

--- a/src/main/java/com/example/Spot/store/application/service/CategoryService.java
+++ b/src/main/java/com/example/Spot/store/application/service/CategoryService.java
@@ -5,6 +5,7 @@ import java.util.UUID;
 
 import com.example.Spot.store.presentation.dto.request.CategoryRequestDTO;
 import com.example.Spot.store.presentation.dto.response.CategoryResponseDTO;
+import com.example.Spot.user.domain.entity.UserEntity;
 
 public interface CategoryService {
 
@@ -18,5 +19,5 @@ public interface CategoryService {
 
     CategoryResponseDTO.CategoryDetail update(UUID categoryId, CategoryRequestDTO.Update request);
 
-    void delete(UUID categoryId);
+    void delete(UUID categoryId, UserEntity user);
 }

--- a/src/main/java/com/example/Spot/store/application/service/CategoryServiceImpl.java
+++ b/src/main/java/com/example/Spot/store/application/service/CategoryServiceImpl.java
@@ -4,6 +4,7 @@ import java.util.List;
 import java.util.UUID;
 import java.util.stream.Collectors;
 
+import com.example.Spot.user.domain.entity.UserEntity;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -109,12 +110,12 @@ public class CategoryServiceImpl implements CategoryService {
     // delete
     @Override
     @Transactional
-    public void delete(UUID categoryId) {
+    public void delete(UUID categoryId, UserEntity user) {
         CategoryEntity category = categoryRepository.findByIdAndIsDeletedFalse(categoryId)
                 .orElseThrow(() -> new IllegalArgumentException("Category not found: " + categoryId));
 
         // soft delete
-        category.softDelete();
+        category.softDelete(user.getId());
     }
 
 

--- a/src/main/java/com/example/Spot/store/application/service/StoreService.java
+++ b/src/main/java/com/example/Spot/store/application/service/StoreService.java
@@ -159,7 +159,7 @@ public class StoreService {
         StoreEntity store = findStoreWithAuthority(storeId, currentUser);
         
         // 6.2 공통 메서드 호출
-        store.softDelete();
+        store.softDelete(userId);
     }
     
     // 7. 매장 이름으로 검색

--- a/src/main/java/com/example/Spot/store/presentation/controller/CategoryController.java
+++ b/src/main/java/com/example/Spot/store/presentation/controller/CategoryController.java
@@ -3,8 +3,12 @@ package com.example.Spot.store.presentation.controller;
 import java.util.List;
 import java.util.UUID;
 
+import com.example.Spot.infra.auth.security.CustomUserDetails;
+import com.example.Spot.user.domain.entity.UserEntity;
+import com.example.Spot.user.domain.repository.UserRepository;
 import org.springframework.http.HttpStatus;
 import org.springframework.security.access.prepost.PreAuthorize;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PatchMapping;
@@ -63,7 +67,8 @@ public class CategoryController {
     @PreAuthorize("hasAnyRole('MASTER','MANAGER')")
     @DeleteMapping("/{categoryId}")
     @ResponseStatus(HttpStatus.NO_CONTENT)
-    public void delete(@PathVariable UUID categoryId) {
-        categoryService.delete(categoryId);
+    public void delete(@PathVariable UUID categoryId, @AuthenticationPrincipal CustomUserDetails principal) {
+        UserEntity user = principal.getUserEntity();
+        categoryService.delete(categoryId, user);
     }
 }

--- a/src/main/java/com/example/Spot/user/application/service/UserService.java
+++ b/src/main/java/com/example/Spot/user/application/service/UserService.java
@@ -53,7 +53,7 @@ public class UserService {
         UserEntity user = userRepository.findById(loginUserId)
                 .orElseThrow(() -> new IllegalArgumentException("사용자를 찾을 수 없습니다."));
 
-        user.softDelete();
+        user.softDelete(user.getId());
     }
     
 

--- a/src/main/java/com/example/Spot/user/domain/Role.java
+++ b/src/main/java/com/example/Spot/user/domain/Role.java
@@ -1,7 +1,6 @@
 package com.example.Spot.user.domain;
 
 public enum Role {
-    ADMIN,
     CUSTOMER,
     OWNER,
     CHEF,

--- a/src/main/java/com/example/Spot/user/domain/entity/ResetTokenEntity.java
+++ b/src/main/java/com/example/Spot/user/domain/entity/ResetTokenEntity.java
@@ -41,14 +41,5 @@ public class ResetTokenEntity extends UpdateBaseEntity {
     @Column(name = "used_at")
     private LocalDateTime usedAt;
 
-    public boolean isUsable(LocalDateTime now) {
-        return !getIsDeleted()
-                && usedAt == null
-                && expiresAt.isAfter(now);
-    }
 
-    public void markUsed() {
-        this.usedAt = LocalDateTime.now();
-        softDelete();
-    }
 }

--- a/src/main/java/com/example/Spot/user/presentation/controller/MasterController.java
+++ b/src/main/java/com/example/Spot/user/presentation/controller/MasterController.java
@@ -6,11 +6,11 @@ import org.springframework.web.bind.annotation.ResponseBody;
 
 @Controller
 @ResponseBody
-public class AdminController {
+public class MasterController {
 
-    @GetMapping("/api/admin")
-    public String adminP() {
+    @GetMapping("/api/master")
+    public String masterP() {
 
-        return "admin Controller";
+        return "master Controller";
     }
 }

--- a/src/test/java/com/example/Spot/user/presentation/controller/UserServiceTest.java
+++ b/src/test/java/com/example/Spot/user/presentation/controller/UserServiceTest.java
@@ -112,7 +112,7 @@ class UserServiceTest {
                 .andReturn();
 
 
-        // then: JWT authorization: bearer로 보내면 인증 붙는지 확인
+        // then: JW//T authorization: bearer로 보내면 인증 붙는지 확인
         // 1. authorization 헤더에서 jwt 확인
         String authHeader = loginResult.getResponse().getHeader("Authorization");
         assertThat(authHeader).isNotNull();


### PR DESCRIPTION
- ADMIN role 삭제 후 admin controller -> master controller로 수정했습니다. (추후 관리자페이지 가능성)
- Login URL을 /api/login으로,  JSON형식으로 request를 입력받도록 수정했습니다.
- Base Entity
  - deleted_by -> delete메서드들의 인자 변경(userid) -> user.getID() 등으로 수정했습니다.
- created_by -> 회원가입 시 NULL 에러 -> created_by: 0(SYSTEM)이 되도록 (auditorawareimpl 생성)


여러 파일의 자잘한 오류 해결했으니 확인 부탁드립니다. 특히 controller 등에서 'ADMIN'으로 role에 따라 접근하는 정책이 남아있는지 확인 부탁드립니다.