### PR TITLE
chore(#207): Store에 AOP 적용

### DIFF
--- a/src/main/java/com/example/Spot/store/infrastructure/aop/AdminOnly.java
+++ b/src/main/java/com/example/Spot/store/infrastructure/aop/AdminOnly.java
@@ -1,0 +1,11 @@
+package com.example.Spot.store.infrastructure.aop;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+@Target(ElementType.METHOD)
+@Retention(RetentionPolicy.RUNTIME)
+public @interface AdminOnly {
+}

--- a/src/main/java/com/example/Spot/store/infrastructure/aop/StoreAspect.java
+++ b/src/main/java/com/example/Spot/store/infrastructure/aop/StoreAspect.java
@@ -1,0 +1,126 @@
+package com.example.Spot.store.infrastructure.aop;
+
+import java.util.UUID;
+
+import org.aspectj.lang.ProceedingJoinPoint;
+import org.aspectj.lang.annotation.Around;
+import org.aspectj.lang.annotation.Aspect;
+import org.springframework.security.access.AccessDeniedException;
+import org.springframework.stereotype.Component;
+
+import com.example.Spot.store.domain.entity.StoreEntity;
+import com.example.Spot.store.domain.repository.StoreRepository;
+import com.example.Spot.user.domain.Role;
+import com.example.Spot.user.domain.entity.UserEntity;
+import com.example.Spot.user.domain.repository.UserRepository;
+
+import jakarta.persistence.EntityNotFoundException;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+
+@Slf4j
+@Aspect
+@Component
+@RequiredArgsConstructor
+public class StoreAspect {
+
+    private final UserRepository userRepository;
+    private final StoreRepository storeRepository;
+
+    @Around("@annotation(validateUser)")
+    public Object handleValidateUser(
+            ProceedingJoinPoint joinPoint,
+            ValidateUser validateUser) throws Throwable {
+
+        Integer userId = (Integer) joinPoint.getArgs()[0];
+
+        log.debug("[User 검증] UserId: {}", userId);
+
+        UserEntity user = userRepository.findById(userId)
+                .orElseThrow(() -> new EntityNotFoundException("사용자를 찾을 수 없습니다."));
+
+        boolean isAdmin = user.getRole() == Role.MASTER || user.getRole() == Role.MANAGER;
+
+        StoreValidationContext.setCurrentUser(user);
+        StoreValidationContext.setIsAdmin(isAdmin);
+
+        try {
+            return joinPoint.proceed();
+        } finally {
+            StoreValidationContext.clearCurrentUser();
+            StoreValidationContext.clearIsAdmin();
+        }
+    }
+
+    @Around("@annotation(adminOnly)")
+    public Object handleAdminOnly(
+            ProceedingJoinPoint joinPoint,
+            AdminOnly adminOnly) throws Throwable {
+
+        Integer userId = (Integer) joinPoint.getArgs()[0];
+
+        log.debug("[관리자 권한 검증] UserId: {}", userId);
+
+        UserEntity user = userRepository.findById(userId)
+                .orElseThrow(() -> new EntityNotFoundException("사용자를 찾을 수 없습니다."));
+
+        boolean isAdmin = user.getRole() == Role.MASTER || user.getRole() == Role.MANAGER;
+
+        if (!isAdmin) {
+            throw new AccessDeniedException("관리자만 접근할 수 있습니다.");
+        }
+
+        StoreValidationContext.setCurrentUser(user);
+        StoreValidationContext.setIsAdmin(true);
+
+        try {
+            return joinPoint.proceed();
+        } finally {
+            StoreValidationContext.clearCurrentUser();
+            StoreValidationContext.clearIsAdmin();
+        }
+    }
+
+    @Around("@annotation(validateStoreAuthority)")
+    public Object handleValidateStoreAuthority(
+            ProceedingJoinPoint joinPoint,
+            ValidateStoreAuthority validateStoreAuthority) throws Throwable {
+
+        UUID storeId = (UUID) joinPoint.getArgs()[0];
+        Integer userId = (Integer) joinPoint.getArgs()[1];
+
+        log.debug("[매장 권한 검증] StoreId: {}, UserId: {}", storeId, userId);
+
+        // User 조회 및 관리자 여부 확인
+        UserEntity user = userRepository.findById(userId)
+                .orElseThrow(() -> new EntityNotFoundException("사용자를 찾을 수 없습니다."));
+
+        boolean isAdmin = user.getRole() == Role.MASTER || user.getRole() == Role.MANAGER;
+
+        // Store 조회
+        StoreEntity store = storeRepository.findByIdWithDetails(storeId, isAdmin)
+                .orElseThrow(() -> new EntityNotFoundException("매장을 찾을 수 없거나 접근 권한이 없습니다."));
+
+        // 관리자가 아닌 경우 소유권 검증
+        if (!isAdmin) {
+            boolean isRealOwner = store.getUsers().stream()
+                    .anyMatch(su -> su.getUser().getId().equals(user.getId())
+                            && su.getUser().getRole() == Role.OWNER);
+
+            if (!isRealOwner) {
+                throw new AccessDeniedException("해당 매장에 대한 관리 권한이 없습니다.");
+            }
+        }
+
+        // ThreadLocal에 저장
+        StoreValidationContext.setCurrentStore(store);
+        StoreValidationContext.setCurrentUser(user);
+        StoreValidationContext.setIsAdmin(isAdmin);
+
+        try {
+            return joinPoint.proceed();
+        } finally {
+            StoreValidationContext.clearAll();
+        }
+    }
+}

--- a/src/main/java/com/example/Spot/store/infrastructure/aop/StoreValidationContext.java
+++ b/src/main/java/com/example/Spot/store/infrastructure/aop/StoreValidationContext.java
@@ -1,0 +1,58 @@
+package com.example.Spot.store.infrastructure.aop;
+
+import com.example.Spot.store.domain.entity.StoreEntity;
+import com.example.Spot.user.domain.entity.UserEntity;
+
+
+public class StoreValidationContext {
+
+    private static final ThreadLocal<StoreEntity> CURRENT_STORE = new ThreadLocal<>();
+    private static final ThreadLocal<UserEntity> CURRENT_USER = new ThreadLocal<>();
+    private static final ThreadLocal<Boolean> IS_ADMIN = new ThreadLocal<>();
+
+    // Store 관련 메서드
+    public static void setCurrentStore(StoreEntity store) {
+        CURRENT_STORE.set(store);
+    }
+
+    public static StoreEntity getCurrentStore() {
+        return CURRENT_STORE.get();
+    }
+
+    public static void clearCurrentStore() {
+        CURRENT_STORE.remove();
+    }
+
+    // User 관련 메서드
+    public static void setCurrentUser(UserEntity user) {
+        CURRENT_USER.set(user);
+    }
+
+    public static UserEntity getCurrentUser() {
+        return CURRENT_USER.get();
+    }
+
+    public static void clearCurrentUser() {
+        CURRENT_USER.remove();
+    }
+
+    // Admin 플래그 관련 메서드
+    public static void setIsAdmin(boolean isAdmin) {
+        IS_ADMIN.set(isAdmin);
+    }
+
+    public static Boolean getIsAdmin() {
+        return IS_ADMIN.get();
+    }
+
+    public static void clearIsAdmin() {
+        IS_ADMIN.remove();
+    }
+
+    // 모든 컨텍스트 클리어
+    public static void clearAll() {
+        CURRENT_STORE.remove();
+        CURRENT_USER.remove();
+        IS_ADMIN.remove();
+    }
+}

--- a/src/main/java/com/example/Spot/store/infrastructure/aop/ValidateStoreAuthority.java
+++ b/src/main/java/com/example/Spot/store/infrastructure/aop/ValidateStoreAuthority.java
@@ -1,0 +1,11 @@
+package com.example.Spot.store.infrastructure.aop;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+@Target(ElementType.METHOD)
+@Retention(RetentionPolicy.RUNTIME)
+public @interface ValidateStoreAuthority {
+}

--- a/src/main/java/com/example/Spot/store/infrastructure/aop/ValidateUser.java
+++ b/src/main/java/com/example/Spot/store/infrastructure/aop/ValidateUser.java
@@ -1,0 +1,11 @@
+package com.example.Spot.store.infrastructure.aop;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+@Target(ElementType.METHOD)
+@Retention(RetentionPolicy.RUNTIME)
+public @interface ValidateUser {
+}


### PR DESCRIPTION
Store Service에서 Entity를 조회하는 로직을 수정하였습니다. MSA 전환을 고려하여 AOP에서 Entity 조회 관련 로직을 처리하고, Service에서는 데이터를 어떻게 가공할지에 대한 설명만 있도록 분리하였습니다.

- updateStore: UserEntity 조회 1회 + StoreEntity 조회 1회 → 0회 (AOP에서 처리)
- updateStoreStaff: UserEntity 조회 1회 + StoreEntity 조회 1회 → 0회 (AOP에서 처리)
- updateStoreStatus: UserEntity 조회 1회 + 권한 검증 로직 → 0회 (AOP에서 처리)
- getMyStores: UserEntity 조회 1회 → 0회 (AOP에서 처리)