### PR TITLE
chore(#207): Order에 AOP 적용

### DIFF
--- a/src/main/java/com/example/Spot/order/application/service/OrderServiceImpl.java
+++ b/src/main/java/com/example/Spot/order/application/service/OrderServiceImpl.java
@@ -22,6 +22,11 @@ import com.example.Spot.order.domain.entity.OrderItemOptionEntity;
 import com.example.Spot.order.domain.enums.CancelledBy;
 import com.example.Spot.order.domain.enums.OrderStatus;
 import com.example.Spot.order.domain.repository.OrderRepository;
+import com.example.Spot.order.infrastructure.aop.OrderStatusChange;
+import com.example.Spot.order.infrastructure.aop.OrderValidationContext;
+import com.example.Spot.order.infrastructure.aop.PaymentCancelTrace;
+import com.example.Spot.order.infrastructure.aop.StoreOwnershipRequired;
+import com.example.Spot.order.infrastructure.aop.ValidateStoreAndMenu;
 import com.example.Spot.order.presentation.dto.request.OrderCreateRequestDto;
 import com.example.Spot.order.presentation.dto.request.OrderItemOptionRequestDto;
 import com.example.Spot.order.presentation.dto.request.OrderItemRequestDto;
@@ -62,16 +67,11 @@ public class OrderServiceImpl implements OrderService {
 
     @Override
     @Transactional
+    @ValidateStoreAndMenu
     public OrderResponseDto createOrder(OrderCreateRequestDto requestDto, Integer userId) {
-        StoreEntity store = storeRepository.findById(requestDto.getStoreId())
-                .orElseThrow(() -> new IllegalArgumentException("존재하지 않는 가게입니다."));
-
-        // 영업시간 체크
-        // if (!store.isOpenNow()) {
-        //     throw new IllegalArgumentException(
-        //             String.format("현재 영업시간이 아닙니다. 영업시간: %s ~ %s",
-        //                     store.getOpenTime(), store.getCloseTime()));
-        // }
+        
+        // AOP에서 검증한 엔티티를 ThreadLocal Context에서 가져옴 (DB 재조회 없음)
+        StoreEntity store = OrderValidationContext.getStore();
 
         String orderNumber = generateOrderNumber();
 
@@ -84,13 +84,9 @@ public class OrderServiceImpl implements OrderService {
                 .request(requestDto.getRequest())
                 .build();
 
+        // Menu 및 MenuOption도 Context에서 가져옴 (DB 재조회 없음) --> 기존 로직에서 성능 개선을 함. DB 조회 횟수가 줄어들음
         for (OrderItemRequestDto itemDto : requestDto.getOrderItems()) {
-            MenuEntity menu = menuRepository.findById(itemDto.getMenuId())
-                    .orElseThrow(() -> new IllegalArgumentException("존재하지 않는 메뉴입니다: " + itemDto.getMenuId()));
-
-            if (!menu.getIsAvailable()) {
-                throw new IllegalArgumentException("판매 중지된 메뉴입니다: " + menu.getName());
-            }
+            MenuEntity menu = OrderValidationContext.getMenu(itemDto.getMenuId());
 
             OrderItemEntity orderItem = OrderItemEntity.builder()
                     .menu(menu)
@@ -98,12 +94,7 @@ public class OrderServiceImpl implements OrderService {
                     .build();
 
             for (OrderItemOptionRequestDto optionDto : itemDto.getOptions()) {
-                MenuOptionEntity menuOption = menuOptionRepository.findById(optionDto.getMenuOptionId())
-                        .orElseThrow(() -> new IllegalArgumentException("존재하지 않는 옵션입니다: " + optionDto.getMenuOptionId()));
-
-                if (!menuOption.isAvailable()) {
-                    throw new IllegalArgumentException("선택할 수 없는 옵션입니다: " + menuOption.getName());
-                }
+                MenuOptionEntity menuOption = OrderValidationContext.getMenuOption(optionDto.getMenuOptionId());
 
                 OrderItemOptionEntity orderItemOption = OrderItemOptionEntity.builder()
                         .menuOption(menuOption)
@@ -160,8 +151,9 @@ public class OrderServiceImpl implements OrderService {
     }
 
     @Override
+    @StoreOwnershipRequired
     public List<OrderResponseDto> getChefTodayOrders(Integer userId) {
-        UUID storeId = getStoreIdByUserId(userId);
+        UUID storeId = OrderValidationContext.getCurrentStoreId();
         LocalDateTime[] range = getDateRange(LocalDateTime.now());
         return orderRepository.findTodayActiveOrdersByStoreId(storeId, range[0], range[1]).stream()
                 .map(OrderResponseDto::from)
@@ -169,14 +161,16 @@ public class OrderServiceImpl implements OrderService {
     }
 
     @Override
+    @StoreOwnershipRequired
     public List<OrderResponseDto> getMyStoreOrders(Integer userId, Integer customerId, LocalDateTime date, OrderStatus status) {
-        UUID storeId = getStoreIdByUserId(userId);
+        UUID storeId = OrderValidationContext.getCurrentStoreId();
         return getStoreOrdersByFilters(storeId, customerId, date, status);
     }
 
     @Override
+    @StoreOwnershipRequired
     public List<OrderResponseDto> getMyStoreActiveOrders(Integer userId) {
-        UUID storeId = getStoreIdByUserId(userId);
+        UUID storeId = OrderValidationContext.getCurrentStoreId();
         return orderRepository.findActiveOrdersByStoreId(storeId).stream()
                 .map(OrderResponseDto::from)
                 .collect(Collectors.toList());
@@ -212,6 +206,7 @@ public class OrderServiceImpl implements OrderService {
     }
 
     @Override
+    @StoreOwnershipRequired
     public Page<OrderResponseDto> getMyStoreOrdersWithPagination(
             Integer userId,
             Integer customerId,
@@ -219,7 +214,7 @@ public class OrderServiceImpl implements OrderService {
             OrderStatus status,
             Pageable pageable) {
 
-        UUID storeId = getStoreIdByUserId(userId);
+        UUID storeId = OrderValidationContext.getCurrentStoreId();
         LocalDateTime[] range = date != null ? getDateRange(date) : new LocalDateTime[]{null, null};
 
         Page<OrderEntity> orderPage = orderRepository.findStoreOrdersWithFilters(
@@ -254,50 +249,50 @@ public class OrderServiceImpl implements OrderService {
 
     @Override
     @Transactional
+    @OrderStatusChange("ACCEPT")
     public OrderResponseDto acceptOrder(UUID orderId, Integer estimatedTime) {
-        OrderEntity order = orderRepository.findById(orderId)
-                .orElseThrow(() -> new IllegalArgumentException("존재하지 않는 주문입니다."));
-        
+        OrderEntity order = OrderValidationContext.getCurrentOrder();
+
         order.acceptOrder(estimatedTime);
         return OrderResponseDto.from(order);
     }
 
     @Override
     @Transactional
+    @OrderStatusChange("REJECT")
     public OrderResponseDto rejectOrder(UUID orderId, String reason) {
-        OrderEntity order = orderRepository.findById(orderId)
-                .orElseThrow(() -> new IllegalArgumentException("존재하지 않는 주문입니다."));
-        
+        OrderEntity order = OrderValidationContext.getCurrentOrder();
+
         order.rejectOrder(reason);
         return OrderResponseDto.from(order);
     }
 
     @Override
     @Transactional
+    @OrderStatusChange("COOKING")
     public OrderResponseDto startCooking(UUID orderId) {
-        OrderEntity order = orderRepository.findById(orderId)
-                .orElseThrow(() -> new IllegalArgumentException("존재하지 않는 주문입니다."));
-        
+        OrderEntity order = OrderValidationContext.getCurrentOrder();
+
         order.startCooking();
         return OrderResponseDto.from(order);
     }
 
     @Override
     @Transactional
+    @OrderStatusChange("READY")
     public OrderResponseDto readyForPickup(UUID orderId) {
-        OrderEntity order = orderRepository.findById(orderId)
-                .orElseThrow(() -> new IllegalArgumentException("존재하지 않는 주문입니다."));
-        
+        OrderEntity order = OrderValidationContext.getCurrentOrder();
+
         order.readyForPickup();
         return OrderResponseDto.from(order);
     }
 
     @Override
     @Transactional
+    @OrderStatusChange("COMPLETE")
     public OrderResponseDto completeOrder(UUID orderId) {
-        OrderEntity order = orderRepository.findById(orderId)
-                .orElseThrow(() -> new IllegalArgumentException("존재하지 않는 주문입니다."));
-        
+        OrderEntity order = OrderValidationContext.getCurrentOrder();
+
         order.completeOrder();
         return OrderResponseDto.from(order);
     }
@@ -332,6 +327,7 @@ public class OrderServiceImpl implements OrderService {
         return OrderResponseDto.from(order);
     }
 
+    @PaymentCancelTrace
     private void cancelPaymentIfExists(UUID orderId, String cancelReason) {
         // 해당 주문의 완료된 결제가 있는지 확인
         Optional<PaymentEntity> paymentOpt = paymentRepository.findActivePaymentByOrderId(orderId);

--- a/src/main/java/com/example/Spot/order/infrastructure/aop/OrderAspect.java
+++ b/src/main/java/com/example/Spot/order/infrastructure/aop/OrderAspect.java
@@ -1,0 +1,169 @@
+package com.example.Spot.order.infrastructure.aop;
+
+import java.util.UUID;
+
+import org.aspectj.lang.ProceedingJoinPoint;
+import org.aspectj.lang.annotation.Around;
+import org.aspectj.lang.annotation.Aspect;
+import org.springframework.stereotype.Component;
+
+import com.example.Spot.menu.domain.entity.MenuEntity;
+import com.example.Spot.menu.domain.entity.MenuOptionEntity;
+import com.example.Spot.menu.domain.repository.MenuOptionRepository;
+import com.example.Spot.menu.domain.repository.MenuRepository;
+import com.example.Spot.order.domain.entity.OrderEntity;
+import com.example.Spot.order.domain.repository.OrderRepository;
+import com.example.Spot.order.infrastructure.aop.OrderValidationContext.ContextData;
+import com.example.Spot.order.presentation.dto.request.OrderCreateRequestDto;
+import com.example.Spot.order.presentation.dto.request.OrderItemOptionRequestDto;
+import com.example.Spot.order.presentation.dto.request.OrderItemRequestDto;
+import com.example.Spot.store.domain.entity.StoreEntity;
+import com.example.Spot.store.domain.entity.StoreUserEntity;
+import com.example.Spot.store.domain.repository.StoreRepository;
+import com.example.Spot.store.domain.repository.StoreUserRepository;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+
+@Slf4j
+@Aspect
+@Component
+@RequiredArgsConstructor
+public class OrderAspect {
+
+    private final StoreRepository storeRepository;
+    private final MenuRepository menuRepository;
+    private final MenuOptionRepository menuOptionRepository;
+    private final OrderRepository orderRepository;
+    private final StoreUserRepository storeUserRepository;
+
+    @Around("@annotation(validateStoreAndMenu)")
+    public Object handleValidateStoreAndMenu(
+            ProceedingJoinPoint joinPoint,
+            ValidateStoreAndMenu validateStoreAndMenu) throws Throwable {
+
+        try {
+            OrderCreateRequestDto requestDto = (OrderCreateRequestDto) joinPoint.getArgs()[0];
+            ContextData contextData = new ContextData();
+
+            StoreEntity store = storeRepository.findById(requestDto.getStoreId())
+                    .orElseThrow(() -> new IllegalArgumentException("존재하지 않는 가게입니다."));
+            contextData.setStore(store);
+
+            for (OrderItemRequestDto itemDto : requestDto.getOrderItems()) {
+                MenuEntity menu = menuRepository.findById(itemDto.getMenuId())
+                        .orElseThrow(() -> new IllegalArgumentException(
+                                "존재하지 않는 메뉴입니다: " + itemDto.getMenuId()));
+
+                if (!menu.getIsAvailable()) {
+                    throw new IllegalArgumentException("판매 중지된 메뉴입니다: " + menu.getName());
+                }
+
+                contextData.addMenu(itemDto.getMenuId(), menu);
+
+                for (OrderItemOptionRequestDto optionDto : itemDto.getOptions()) {
+                    MenuOptionEntity menuOption = menuOptionRepository.findById(optionDto.getMenuOptionId())
+                            .orElseThrow(() -> new IllegalArgumentException(
+                                    "존재하지 않는 옵션입니다: " + optionDto.getMenuOptionId()));
+
+                    if (!menuOption.isAvailable()) {
+                        throw new IllegalArgumentException(
+                                "선택할 수 없는 옵션입니다: " + menuOption.getName());
+                    }
+
+                    contextData.addMenuOption(optionDto.getMenuOptionId(), menuOption);
+                }
+            }
+
+            OrderValidationContext.set(contextData);
+
+            return joinPoint.proceed();
+
+        } finally {
+            OrderValidationContext.clear();
+        }
+    }
+
+    @Around("@annotation(orderStatusChange)")
+    public Object handleOrderStatusChange(
+            ProceedingJoinPoint joinPoint,
+            OrderStatusChange orderStatusChange) throws Throwable {
+
+        UUID orderId = (UUID) joinPoint.getArgs()[0];
+        String statusType = orderStatusChange.value();
+        String methodName = joinPoint.getSignature().getName();
+
+        log.info("[주문 상태 변경] 시작 - OrderId: {}, Type: {}, Method: {}", orderId, statusType, methodName);
+
+        try {
+            OrderEntity order = orderRepository.findById(orderId)
+                    .orElseThrow(() -> new IllegalArgumentException("존재하지 않는 주문입니다."));
+
+            OrderValidationContext.setCurrentOrder(order);
+
+            Object result = joinPoint.proceed();
+
+            log.info("[주문 상태 변경] 완료 - OrderId: {}, Type: {}, NewStatus: {}",
+                    orderId, statusType, order.getOrderStatus());
+
+            // TODO: 향후 이벤트 발행 (알림, 웹소켓 등)
+            // eventPublisher.publishOrderStatusChangedEvent(order, statusType);
+
+            return result;
+
+        } catch (Exception e) {
+            log.error("[주문 상태 변경] 실패 - OrderId: {}, Type: {}, Error: {}",
+                    orderId, statusType, e.getMessage(), e);
+            throw e;
+        } finally {
+            OrderValidationContext.clearCurrentOrder();
+        }
+    }
+
+    @Around("@annotation(paymentCancelTrace)")
+    public Object handlePaymentCancelTrace(
+            ProceedingJoinPoint joinPoint,
+            PaymentCancelTrace paymentCancelTrace) throws Throwable {
+
+        UUID orderId = (UUID) joinPoint.getArgs()[0];
+        String cancelReason = (String) joinPoint.getArgs()[1];
+
+        log.info("[결제 취소] 시작 - OrderId: {}, Reason: {}", orderId, cancelReason);
+
+        try {
+            Object result = joinPoint.proceed();
+            log.info("[결제 취소] 완료 - OrderId: {}", orderId);
+            return result;
+
+        } catch (Exception e) {
+            log.error("[결제 취소] 실패 - OrderId: {}, Error: {}", orderId, e.getMessage(), e);
+            throw e;
+        }
+    }
+
+    @Around("@annotation(storeOwnershipRequired)")
+    public Object handleStoreOwnershipRequired(
+            ProceedingJoinPoint joinPoint,
+            StoreOwnershipRequired storeOwnershipRequired) throws Throwable {
+
+        Integer userId = (Integer) joinPoint.getArgs()[0];
+
+        log.debug("[가게 소유권 검증] UserId: {}", userId);
+
+        StoreUserEntity storeUser = storeUserRepository.findFirstByUser_Id(userId);
+        if (storeUser == null) {
+            throw new IllegalArgumentException("소속된 매장이 없습니다.");
+        }
+
+        UUID storeId = storeUser.getStore().getId();
+
+        // ThreadLocal에 storeId 저장 (서비스에서 재조회 방지)
+        OrderValidationContext.setCurrentStoreId(storeId);
+
+        try {
+            return joinPoint.proceed();
+        } finally {
+            OrderValidationContext.clearCurrentStoreId();
+        }
+    }
+}

--- a/src/main/java/com/example/Spot/order/infrastructure/aop/OrderStatusChange.java
+++ b/src/main/java/com/example/Spot/order/infrastructure/aop/OrderStatusChange.java
@@ -1,0 +1,13 @@
+package com.example.Spot.order.infrastructure.aop;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+@Target(ElementType.METHOD)
+@Retention(RetentionPolicy.RUNTIME)
+public @interface OrderStatusChange {
+    
+    String value() default "";
+}

--- a/src/main/java/com/example/Spot/order/infrastructure/aop/OrderValidationContext.java
+++ b/src/main/java/com/example/Spot/order/infrastructure/aop/OrderValidationContext.java
@@ -1,0 +1,100 @@
+package com.example.Spot.order.infrastructure.aop;
+
+import java.util.HashMap;
+import java.util.Map;
+import java.util.UUID;
+
+import com.example.Spot.menu.domain.entity.MenuEntity;
+import com.example.Spot.menu.domain.entity.MenuOptionEntity;
+import com.example.Spot.order.domain.entity.OrderEntity;
+import com.example.Spot.store.domain.entity.StoreEntity;
+
+public class OrderValidationContext {
+
+    private static final ThreadLocal<ContextData> CONTEXT = new ThreadLocal<>();
+    private static final ThreadLocal<OrderEntity> CURRENT_ORDER = new ThreadLocal<>();
+    private static final ThreadLocal<UUID> CURRENT_STORE_ID = new ThreadLocal<>();
+
+    public static class ContextData {
+        private StoreEntity store;
+        private Map<UUID, MenuEntity> menuMap = new HashMap<>();
+        private Map<UUID, MenuOptionEntity> menuOptionMap = new HashMap<>();
+
+        public StoreEntity getStore() {
+            return store;
+        }
+
+        public void setStore(StoreEntity store) {
+            this.store = store;
+        }
+
+        public void addMenu(UUID menuId, MenuEntity menu) {
+            menuMap.put(menuId, menu);
+        }
+
+        public MenuEntity getMenu(UUID menuId) {
+            return menuMap.get(menuId);
+        }
+
+        public void addMenuOption(UUID optionId, MenuOptionEntity option) {
+            menuOptionMap.put(optionId, option);
+        }
+
+        public MenuOptionEntity getMenuOption(UUID optionId) {
+            return menuOptionMap.get(optionId);
+        }
+    }
+
+    public static void set(ContextData data) {
+        CONTEXT.set(data);
+    }
+
+    public static ContextData get() {
+        return CONTEXT.get();
+    }
+
+    public static void clear() {
+        CONTEXT.remove();
+    }
+
+    public static StoreEntity getStore() {
+        ContextData data = get();
+        return data != null ? data.getStore() : null;
+    }
+
+    public static MenuEntity getMenu(UUID menuId) {
+        ContextData data = get();
+        return data != null ? data.getMenu(menuId) : null;
+    }
+
+    public static MenuOptionEntity getMenuOption(UUID optionId) {
+        ContextData data = get();
+        return data != null ? data.getMenuOption(optionId) : null;
+    }
+
+    // 주문 상태 변경용 메서드
+    public static void setCurrentOrder(OrderEntity order) {
+        CURRENT_ORDER.set(order);
+    }
+
+    public static OrderEntity getCurrentOrder() {
+        return CURRENT_ORDER.get();
+    }
+
+    public static void clearCurrentOrder() {
+        CURRENT_ORDER.remove();
+    }
+
+    // 가게 소유권 검증용 메서드
+    public static void setCurrentStoreId(UUID storeId) {
+        CURRENT_STORE_ID.set(storeId);
+    }
+
+    public static UUID getCurrentStoreId() {
+        return CURRENT_STORE_ID.get();
+    }
+
+    public static void clearCurrentStoreId() {
+        CURRENT_STORE_ID.remove();
+    }
+}

--- a/src/main/java/com/example/Spot/order/infrastructure/aop/PaymentCancelTrace.java
+++ b/src/main/java/com/example/Spot/order/infrastructure/aop/PaymentCancelTrace.java
@@ -1,0 +1,11 @@
+package com.example.Spot.order.infrastructure.aop;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+@Target(ElementType.METHOD)
+@Retention(RetentionPolicy.RUNTIME)
+public @interface PaymentCancelTrace {
+}

--- a/src/main/java/com/example/Spot/order/infrastructure/aop/StoreOwnershipRequired.java
+++ b/src/main/java/com/example/Spot/order/infrastructure/aop/StoreOwnershipRequired.java
@@ -1,0 +1,11 @@
+package com.example.Spot.order.infrastructure.aop;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+@Target(ElementType.METHOD)
+@Retention(RetentionPolicy.RUNTIME)
+public @interface StoreOwnershipRequired {
+}

--- a/src/main/java/com/example/Spot/order/infrastructure/aop/ValidateStoreAndMenu.java
+++ b/src/main/java/com/example/Spot/order/infrastructure/aop/ValidateStoreAndMenu.java
@@ -1,0 +1,11 @@
+package com.example.Spot.order.infrastructure.aop;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+@Target(ElementType.METHOD)
+@Retention(RetentionPolicy.RUNTIME)
+public @interface ValidateStoreAndMenu {
+}


### PR DESCRIPTION
MSA 전환시 서비스 로직의 복잡성을 줄이기 위해 Order에 AOP 적용하였습니다. 변경사항은 다음과 같습니다.

createOrder에서 Store, Menu Entity 조회하는 로직을 분리하였습니다. 외부 통신과 관련된 것은 비지니스 로직에서 고려해야 하는 부분이 아니기 때문에 조회 관련 내용을 분리했습니다.

ThreadLocal을 사용하여 한 번 조회된 것을 여러번 재사용할 수 있도록 하였습니다.
주문 상태 변경 메서드에 적용했습니다.

권한 조회 메서드에 적용했습니다.

결제 취소 로직에 적용했습니다.