### PR TITLE
fix(#228): Order에서 발생하는 MultipleBagFetchException 해결

### DIFF
--- a/spot-order/src/main/java/com/example/Spot/order/application/service/OrderServiceImpl.java
+++ b/spot-order/src/main/java/com/example/Spot/order/application/service/OrderServiceImpl.java
@@ -27,6 +27,7 @@ import com.example.Spot.order.domain.entity.OrderItemEntity;
 import com.example.Spot.order.domain.entity.OrderItemOptionEntity;
 import com.example.Spot.order.domain.enums.CancelledBy;
 import com.example.Spot.order.domain.enums.OrderStatus;
+import com.example.Spot.order.domain.repository.OrderItemOptionRepository;
 import com.example.Spot.order.domain.repository.OrderRepository;
 import com.example.Spot.order.infrastructure.aop.OrderStatusChange;
 import com.example.Spot.order.infrastructure.aop.OrderValidationContext;
@@ -48,6 +49,7 @@ import lombok.extern.slf4j.Slf4j;
 public class OrderServiceImpl implements OrderService {
 
     private final OrderRepository orderRepository;
+    private final OrderItemOptionRepository orderItemOptionRepository;
     private final PaymentClient paymentClient;
     private final StoreClient storeClient;
 
@@ -103,9 +105,27 @@ public class OrderServiceImpl implements OrderService {
     }
 
     @Override
+    @Transactional(readOnly = true)
     public OrderResponseDto getOrderById(UUID orderId) {
-        OrderEntity order = orderRepository.findByIdWithDetails(orderId)
+
+        // MultipleBagFetchException이 발생해서 변경을 진행함. 01.26에 진행.
+        OrderEntity order = orderRepository.findByIdWithOrderItems(orderId)
                 .orElseThrow(() -> new IllegalArgumentException("존재하지 않는 주문입니다."));
+
+        List<UUID> orderItemIds = order.getOrderItems().stream()
+                .map(OrderItemEntity::getId)
+                .toList();
+
+        List<OrderItemOptionEntity> options = List.of();
+        if (!orderItemIds.isEmpty()) {
+            options = orderItemOptionRepository.findByOrderItemIdIn(orderItemIds);
+        }
+
+        if (!order.getOrderItems().isEmpty() && !options.isEmpty()) {
+            System.out.println("Order의 아이템 주소: " + System.identityHashCode(order.getOrderItems().get(0)));
+            System.out.println("옵션이 참조하는 아이템 주소: " + System.identityHashCode(options.get(0).getOrderItem()));
+        }
+
         return OrderResponseDto.from(order);
     }
 
@@ -174,6 +194,7 @@ public class OrderServiceImpl implements OrderService {
     }
 
     // ========== 페이지네이션 ==========
+    // MultipleBagFetchException 방지를 위해 Options는 별도 조회 후 1차 캐시 활용
 
     @Override
     public Page<OrderResponseDto> getUserOrdersWithPagination(
@@ -193,6 +214,7 @@ public class OrderServiceImpl implements OrderService {
                 range[1],
                 pageable);
 
+        fetchOrderItemOptions(orderPage.getContent());
         return orderPage.map(OrderResponseDto::from);
     }
 
@@ -216,6 +238,7 @@ public class OrderServiceImpl implements OrderService {
                 range[1],
                 pageable);
 
+        fetchOrderItemOptions(orderPage.getContent());
         return orderPage.map(OrderResponseDto::from);
     }
 
@@ -235,7 +258,23 @@ public class OrderServiceImpl implements OrderService {
                 range[1],
                 pageable);
 
+        fetchOrderItemOptions(orderPage.getContent());
         return orderPage.map(OrderResponseDto::from);
+    }
+
+    /**
+     * Order 목록의 OrderItemOptions를 별도 조회하여 1차 캐시에 로드
+     * MultipleBagFetchException 방지용
+     */
+    private void fetchOrderItemOptions(List<OrderEntity> orders) {
+        List<UUID> orderItemIds = orders.stream()
+                .flatMap(order -> order.getOrderItems().stream())
+                .map(OrderItemEntity::getId)
+                .toList();
+
+        if (!orderItemIds.isEmpty()) {
+            orderItemOptionRepository.findByOrderItemIdIn(orderItemIds);
+        }
     }
 
     @Override

--- a/spot-order/src/main/java/com/example/Spot/order/domain/repository/OrderItemOptionRepository.java
+++ b/spot-order/src/main/java/com/example/Spot/order/domain/repository/OrderItemOptionRepository.java
@@ -21,5 +21,10 @@ public interface OrderItemOptionRepository extends JpaRepository<OrderItemOption
             "WHERE oio.menuOptionId = :menuOptionId " +
             "ORDER BY oio.createdAt DESC")
     List<OrderItemOptionEntity> findByMenuOptionId(@Param("menuOptionId") UUID menuOptionId);
+
+    // Order Entity를 통해 Order Item과 Order Item Option을 한 번에 조회하는 로직을 분해함.
+    @Query("SELECT oio FROM OrderItemOptionEntity oio " +
+            "WHERE oio.orderItem.id IN :orderItemIds")
+    List<OrderItemOptionEntity> findByOrderItemIdIn(@Param("orderItemIds") List<UUID> orderItemIds);
 }
 


### PR DESCRIPTION
컬렉션이 두 번 붙여져 있는 Repository 조회 메서드에서 분리했습니다. DB를 각각 조회한 후 이전 로직과 동일한 방식으로 사용할 수 있도록 추가 작업을 진행했습니다.
현재는 DB 조회 속도가 많이 느린 문제가 있습니다. 추후 개선이 필요합니다. 