### PR TITLE
feat(#240):kafka-group세분화 및 yaml통합

### DIFF
--- a/config/kafka-topics.yml
+++ b/config/kafka-topics.yml
@@ -11,7 +11,9 @@ spring:
       acks: all
       retries: 5
       properties:
-        retry.backoff.ms: 300
+        retry.backoff.ms: 2000
+        reconnect.backoff.ms: 5000
+        reconnect.backoff.max.ms: 30000
         delivery.timeout.ms: 30000
         enable.idempotence: true
         max.in.flight.requests.per.connection: 5
@@ -25,6 +27,12 @@ spring:
       max.poll.interval.ms: 300000
       session.timeout.ms: 15000
       heartbeat.interval.ms: 3000
+      group:
+        order: order-group
+        payment: payment-group
+        customer: customer-group
+        chef: chef-group
+        owner: owner-group
       
     topic:
       order:

--- a/config/spot-order.yml
+++ b/config/spot-order.yml
@@ -5,9 +5,6 @@ spring:
       - file:/config/kafka-topics.yml
   application:
     name: spot-order
-  kafka:
-    consumer:
-      group-id: order-group
       
 server:
   port: 8082

--- a/config/spot-payment.yml
+++ b/config/spot-payment.yml
@@ -5,9 +5,6 @@ spring:
       - file:/config/kafka-topics.yml
   application:
     name: spot-payment
-  kafka:
-    consumer:
-      group-id: payment-group
     
 server:
   port: 8084

--- a/spot-order/src/main/java/com/example/Spot/order/infrastructure/listener/NotificationListener.java
+++ b/spot-order/src/main/java/com/example/Spot/order/infrastructure/listener/NotificationListener.java
@@ -20,7 +20,7 @@ public class NotificationListener {
     private final ObjectMapper objectMapper;
 
     // 1. 유저 결제 수단 필요 알림
-    @KafkaListener(topics = "${spring.kafka.topic.payment-auth.required}", groupId = "notification-customer-group")
+    @KafkaListener(topics = "${spring.kafka.topic.payment-auth.required}", groupId = "${spring.kafka.consumer.group.customer}")
     public void handleAuthRequired(String message, Acknowledgment ack) {
         parseEvent(message, AuthRequiredEvent.class, ack, event ->
                 log.info("🔔 [고객알림] 유저 {}: 결제 수단이 없어 주문이 대기 중입니다. 사유: {}",
@@ -29,7 +29,7 @@ public class NotificationListener {
     }
 
     // 2. 사장님 새 주문 알림
-    @KafkaListener(topics = "${spring.kafka.topic.order.pending}", groupId = "notification-owner-group")
+    @KafkaListener(topics = "${spring.kafka.topic.order.pending}", groupId = "${spring.kafka.consumer.group.owner}")
     public void handleOrderPending(String message, Acknowledgment ack) {
         parseEvent(message, OrderPendingEvent.class, ack, event ->
                 log.info("🔔 [사장알림] 가게 ID {}: 새 주문이 들어왔습니다! (주문 ID: {})",
@@ -38,7 +38,7 @@ public class NotificationListener {
     }
 
     // 3. 주문 수락 - 고객용
-    @KafkaListener(topics = "${spring.kafka.topic.order.accepted}", groupId = "notification-customer-group")
+    @KafkaListener(topics = "${spring.kafka.topic.order.accepted}", groupId = "${spring.kafka.consumer.group.customer}")
     public void handleAcceptedCustomer(String message, Acknowledgment ack) {
         parseEvent(message, OrderAcceptedEvent.class, ack, event ->
                 log.info("🔔 [고객알림] 유저 {}: 주문이 수락되었습니다. {}분 뒤 도착 예정!",
@@ -47,7 +47,7 @@ public class NotificationListener {
     }
 
     // 4. 주문 수락 - 요리사용
-    @KafkaListener(topics = "${spring.kafka.topic.order.accepted}", groupId = "notification-chef-group")
+    @KafkaListener(topics = "${spring.kafka.topic.order.accepted}", groupId = "${spring.kafka.consumer.group.chef}")
     public void handleAcceptedChef(String message, Acknowledgment ack) {
         parseEvent(message, OrderAcceptedEvent.class, ack, event ->
                 log.info("🔔 [주방알림] 주문번호 {}: 조리 시작! (예상시간: {}분)",

--- a/spot-order/src/main/java/com/example/Spot/order/infrastructure/listener/OrderEventListener.java
+++ b/spot-order/src/main/java/com/example/Spot/order/infrastructure/listener/OrderEventListener.java
@@ -20,7 +20,7 @@ public class OrderEventListener {
     private final OrderService orderService;
     private final ObjectMapper objectMapper;
     
-    @KafkaListener(topics = "${spring.kafka.topic.payment.succeeded}", groupId = "${spring.kafka.consumer.group-id}")
+    @KafkaListener(topics = "${spring.kafka.topic.payment.succeeded}", groupId = "${spring.kafka.consumer.group.order}")
     public void handlePaymentSucceeded(String message, Acknowledgment ack) {
         try {
             PaymentSucceededEvent event = objectMapper.readValue(message, PaymentSucceededEvent.class);
@@ -33,7 +33,7 @@ public class OrderEventListener {
         }
     }
     
-    @KafkaListener(topics = "${spring.kafka.topic.payment.refunded}", groupId = "${spring.kafka.consumer.group-id}")
+    @KafkaListener(topics = "${spring.kafka.topic.payment.refunded}", groupId = "${spring.kafka.consumer.group.order}")
     public void handlePaymentRefunded(String message, Acknowledgment ack) {
         try {
             PaymentRefundedEvent event = objectMapper.readValue(message, PaymentRefundedEvent.class);

--- a/spot-payment/src/main/java/com/example/Spot/payments/infrastructure/listener/PaymentListener.java
+++ b/spot-payment/src/main/java/com/example/Spot/payments/infrastructure/listener/PaymentListener.java
@@ -28,7 +28,7 @@ public class PaymentListener {
     private final ObjectMapper objectMapper;
     private final PaymentEventProducer paymentEventProducer;
 
-    @KafkaListener(topics = "${spring.kafka.topic.order.created}", groupId = "${spring.kafka.consumer.group-id}")
+    @KafkaListener(topics = "${spring.kafka.topic.order.created}", groupId = "${spring.kafka.consumer.group.payment}")
     public void handleOrderCreated(String message, Acknowledgment ack) {
         try {
             OrderCreatedEvent event = objectMapper.readValue(message, OrderCreatedEvent.class);
@@ -74,7 +74,7 @@ public class PaymentListener {
     }
     
     // 고객취소, 가게취소, 주문거절 이벤트 수신 시 환불 처리
-    @KafkaListener(topics = "${spring.kafka.topic.order.cancelled}", groupId = "${spring.kafka.consumer.group-id}")
+    @KafkaListener(topics = "${spring.kafka.topic.order.cancelled}", groupId = "${spring.kafka.consumer.group.payment}")
     public void handleOrderCancelled(String message, Acknowledgment ack) {
         try {
             // 1. 이벤트 파싱


### PR DESCRIPTION
각 서버 별 YAML에 분산되어있던 kafka-group를 kafka_topics.yml에서 통합
kafka group세분화
- order
- payment
- customer
- owner
- chef
카프카를 꺼놓고 주문을 발행하는 장애 테스트 및 기능 테스트 통과

