### PR TITLE
주문-결제 장애 테스트 

### DIFF
--- a/spot-order/src/main/java/com/example/Spot/order/domain/entity/OrderEntity.java
+++ b/spot-order/src/main/java/com/example/Spot/order/domain/entity/OrderEntity.java
@@ -226,6 +226,14 @@ public class OrderEntity extends BaseEntity {
         }
     }
     
+    public void markAsRefundError() {
+        if (this.orderStatus != OrderStatus.CANCEL_PENDING) {
+            throw new IllegalStateException("환불 대기 상태가 아닌 주문은 에러 처리를 할 수 없습니다.");
+        }
+        
+        this.orderStatus = OrderStatus.REFUND_ERROR;
+    }
+    
     // 상태 전환 검증
     private void validateStatusTransition(OrderStatus newStatus) {
         if (!this.orderStatus.canTransitionTo(newStatus)) {

--- a/spot-order/src/main/java/com/example/Spot/order/domain/enums/OrderStatus.java
+++ b/spot-order/src/main/java/com/example/Spot/order/domain/enums/OrderStatus.java
@@ -10,7 +10,8 @@ public enum OrderStatus {
     READY("픽업 대기"),
     COMPLETED("픽업 완료"),
     CANCEL_PENDING("취소 처리 중"),
-    CANCELLED("주문 취소");
+    CANCELLED("주문 취소"),
+    REFUND_ERROR("환불 확인 필요");
 
     private final String description;
 
@@ -23,7 +24,7 @@ public enum OrderStatus {
     }
     
     public boolean isFinalStatus() {
-        return this == COMPLETED || this == CANCELLED || this == REJECTED || this == PAYMENT_FAILED;
+        return this == COMPLETED || this == CANCELLED || this == REJECTED || this == PAYMENT_FAILED || this == REFUND_ERROR;
     }
     
     public boolean isPaid() {
@@ -39,7 +40,7 @@ public enum OrderStatus {
             case PENDING -> newStatus == ACCEPTED || newStatus == CANCEL_PENDING;
             case ACCEPTED -> newStatus == COOKING || newStatus == CANCEL_PENDING;
             case COOKING -> newStatus == READY || newStatus == CANCEL_PENDING;
-            case CANCEL_PENDING ->  newStatus == CANCELLED || newStatus ==  REJECTED;
+            case CANCEL_PENDING ->  newStatus == CANCELLED || newStatus ==  REJECTED || newStatus == REFUND_ERROR;
             case READY -> newStatus == COMPLETED;
             default -> false;
         };

--- a/spot-order/src/main/java/com/example/Spot/order/infrastructure/temporal/activity/OrderActivity.java
+++ b/spot-order/src/main/java/com/example/Spot/order/infrastructure/temporal/activity/OrderActivity.java
@@ -21,4 +21,7 @@ public interface OrderActivity {
 
     @ActivityMethod
     void finalizeOrder(UUID orderId);
+    
+    @ActivityMethod
+    void handleRefundTimeout(UUID orderId);
 }

--- a/spot-order/src/main/java/com/example/Spot/order/infrastructure/temporal/workflow/OrderWorkflowImpl.java
+++ b/spot-order/src/main/java/com/example/Spot/order/infrastructure/temporal/workflow/OrderWorkflowImpl.java
@@ -72,8 +72,12 @@ public class OrderWorkflowImpl implements OrderWorkflow {
     }
 
     private void waitForRefundAndFinalize(UUID orderId, OrderActivity activities) {
-        Workflow.await(() -> isRefundCompleted);
-        activities.finalizeOrder(orderId);
+        boolean isSuccess = Workflow.await(Duration.ofMinutes(30), () -> isRefundCompleted);
+        if (isSuccess) {
+            activities.finalizeOrder(orderId);
+        } else {
+            activities.handleRefundTimeout(orderId);
+        }
     }
 
     @Override

--- a/spot-payment/src/main/java/com/example/Spot/payments/infrastructure/temporal/workflow/PaymentCancelWorkflowImpl.java
+++ b/spot-payment/src/main/java/com/example/Spot/payments/infrastructure/temporal/workflow/PaymentCancelWorkflowImpl.java
@@ -29,7 +29,9 @@ public class PaymentCancelWorkflowImpl implements PaymentCancelWorkflow {
                     .setStartToCloseTimeout(Duration.ofMinutes(1))
                     .setRetryOptions(RetryOptions.newBuilder()
                             .setInitialInterval(Duration.ofSeconds(5))
-                            .setMaximumAttempts(8)
+                            .setBackoffCoefficient(2.0)
+                            .setMaximumInterval(Duration.ofMinutes(3)) 
+                            .setMaximumAttempts(15)
                             .setDoNotRetry(DO_NOT_RETRY_EXCEPTIONS)
                             .build())
                     .build());


### PR DESCRIPTION
환불최종실패에 대한 로직 추가

[기본 테스트]
- 주문 생성 - 결제 생성 - 결제 완료 - 주문 완료 - 주문 수락 - 요리 대기 - 요리 완료 - 픽업 완료 
- 주문 생성 - 결제 생성 - 결제 완료 - 주문 완료 - 가게 취소
- 주문 생성 - 결제 생성 - 결제 완료 - 주문 완료 - 주문 수락 - 고객 취소
- 주문 생성 - 결제 생성 - 결제 완료 - 주문 완료 - 주문 거절

[결제 서버 연결 종료] 
- 주문 생성 : kafka-ui의 컨슈머를 통해 consumer Lag로 파악
- 주문 취소 : kafka-ui의 컨슈머를 통해 consumer Lag로 파악

[Kafka 연결 종료]
- Kafka가 복구되면 Connect가 이벤트 자동 발행

[Toss 서버 연결 실패]
- Workflow가 6번 시도 후 실패(4분10초) - 5분 타임아웃으로 주문 취소

[멱등성 및 중복 처리]
- 서버가 재시도하거나 네트워크로 인해 ack 커밋이 되지 않아 중복 이벤트가 소비될 경우
- findByOrderId 혹은 워크플로우 아이디를 통해 중복을 방지
- 위 로직을 통과할 경우 이미 진해중인 기존 ID를 반환하도록 구현
- 그리고 ack 커밋을 통해 이벤트 소비 확정

[결제는 성공했는데 주문 서버가 연결되어있지 않을 때]
- 타임아웃 대기시간 중 서버 혹은 kafka 복구: Connect 혹은 temporal이 재시도
- 타임아웃 이후 복구: 결제 취소에 대한 보상 트랜잭션 필요 - 타임아웃으로 테스트 완료

[결제 취소 요청에 대한 워크플로우 생성]
- 결제 취소 요청에 대한 사가패턴과 리트라이도 적용
- 주문서버에서 `Cacnel_Pending` 타임아웃을 걸고 1시간이 지나도 실패하면`REFUND_ERROR` 상태로 변경

[결제 프로세스 진행 중 사가 패턴 적용]
- 결제가 완료하기 전에 프로세스 종료 - 환불 처리 스킵(멱등성 보장) - temporal이 재시도
- 결제가 완료하고 프로세스 종료 - 사가 패턴 적용 - 타임아웃으로 테스트 완료

[취소 및 거절 로직 테스트] → 아래 모든 테스트 DB 및 Workflow테스트 완료
- `주문 수락대기` 상태에서만 `거절`로 갈 수 있음 (그외 불가능)
- `주문 수락대기`  `주문수락` `요리중` 상태에서는 `주문취소` 상태로 갈 수 있음 
- `픽업대기` 상태에서는 `주문완료` 상태로 갈 수 있음
- `주문거절` `주문취소` `주문완료` 상태는 최종상태로 workflow가 종료됨